### PR TITLE
Insert readthedocs config in shape of a .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,22 @@
+# .readthedocs.yml
+
+version: 2
+
+# Build all formats
+formats: all
+
+# Python environment to build the docs for and install the package in
+python:
+  version: 3.5
+  install:
+    - requirements: requirements.txt
+    - method: pip
+        path: .
+    - method: setuptools
+        path: .
+
+# Sphinx configuration
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+  fail_on_warning: false

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,10 +18,9 @@ python:
       path: .
     - method: setuptools
       path: .
-  system_packages: true
 
 # Sphinx configuration
 sphinx:
   builder: html
-  configuration: docs/conf.py
+  configuration: doc/conf.py
   fail_on_warning: false

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,10 @@ version: 2
 # Build all formats
 formats: all
 
+# Docker image to use for build process
+build:
+  image: latest
+
 # Python environment to build the docs for and install the package in
 python:
   version: 3.5

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,8 +14,6 @@ python:
   version: 3.5
   install:
     - requirements: requirements.txt
-    - method: pip
-        path: .
     - method: setuptools
         path: .
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,8 +14,11 @@ python:
   version: 3.5
   install:
     - requirements: requirements.txt
+    - method: pip
+      path: .
     - method: setuptools
-        path: .
+      path: .
+  system_packages: true
 
 # Sphinx configuration
 sphinx:

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,3 @@
+# _config.yml to configure https://eichstaedtptb.github.io/PyDynamic/
+
 theme: jekyll-theme-slate

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ ipython==6.2.1
 jupyter==1.0.0
 matplotlib==2.1.2
 pytest==3.7.1
-numpy==1.14.0
+numpy==1.16.1
 pandas==0.22.0
 scipy==1.0.0
 sympy==1.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ ipython==6.2.1
 jupyter==1.0.0
 matplotlib==2.1.2
 pytest==3.7.1
-numpy==1.16.1
+numpy==1.14.0
 pandas==0.22.0
 scipy==1.0.0
 sympy==1.1.1


### PR DESCRIPTION
This introduces a `.readthedocs.yml` file in the root directiory of the repository to fix an error in the process of automatically creating the documentation. This file now specifies the python version to use for creating the build environment for the docs to make sure the desired version is used. This setting is not available in the readthedocs-webinterface. It also inserts a comment in ´_config.yml´ which shall explaine the need for the file on first view.