### PR TITLE
Insert module tools into docs and resolve corresponding issue

### DIFF
--- a/doc/PyDynamic.misc.rst
+++ b/doc/PyDynamic.misc.rst
@@ -9,13 +9,19 @@ Tools for 2nd order systems
     :members:
 
 Tools for digital filters
----------------------------------
+-------------------------
 
 .. automodule:: PyDynamic.misc.filterstuff
     :members:
 
 Test signals
----------------------------------
+------------
 
 .. automodule:: PyDynamic.misc.testsignals
+    :members:
+
+Miscellaneous useful helper functions
+-------------------------------------
+
+.. automodule:: PyDynamic.misc.tools
     :members:


### PR DESCRIPTION
Resolve #35 by adapting [docs/PyDynamic.misc.rst](https://github.com/eichstaedtPTB/PyDynamic/blob/master/doc/PyDynamic.misc.rst), specifically inserting a paragraph for ´PyDynamic/misc/tools.py´.