### PR TITLE
Switch to raw docstrings for backslashes

### DIFF
--- a/PyDynamic/misc/filterstuff.py
+++ b/PyDynamic/misc/filterstuff.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
+r"""
 
 A collection of methods which are related to filter design.
 

--- a/PyDynamic/uncertainty/propagate_MonteCarlo.py
+++ b/PyDynamic/uncertainty/propagate_MonteCarlo.py
@@ -14,14 +14,15 @@ This module contains the following functions:
 
 """
 
+import sys
+
 import numpy as np
 import scipy as sp
-import sys
-from scipy.signal import lfilter
 import scipy.stats as stats
+from scipy.signal import lfilter
 
-from ..misc.tools import zerom
 from ..misc.filterstuff import isstable
+from ..misc.tools import zerom
 
 __all__ = ["MC", "SMC"]
 
@@ -58,7 +59,7 @@ class Normal_ZeroCorr():
 
 
 def MC(x,Ux,b,a,Uab,runs=1000,blow=None,alow=None,return_samples=False,shift=0,verbose=True):
-	"""Standard Monte Carlo method
+	r"""Standard Monte Carlo method
 
 	Monte Carlo based propagation of uncertainties for a digital filter (b,a)
 	with uncertainty matrix
@@ -156,9 +157,9 @@ def MC(x,Ux,b,a,Uab,runs=1000,blow=None,alow=None,return_samples=False,shift=0,v
 
 
 
-def SMC(x,noise_std,b,a,Uab=None,runs=1000,Perc=None,blow=None,alow=None,shift=0,\
+def SMC(x,noise_std,b,a,Uab=None,runs=1000,Perc=None,blow=None,alow=None,shift=0,
 			return_samples=False,phi=None,theta=None,Delta=0.0):
-	"""Sequential Monte Carlo method
+	r"""Sequential Monte Carlo method
 
 	Sequential Monte Carlo propagation for a digital filter (b,a) with uncertainty
 	matrix :math:`U_{\theta}` for :math:`\theta=(a_1,\ldots,a_{N_a},b_0,\ldots,b_{N_b})^T`

--- a/build/lib/PyDynamic/misc/filterstuff.py
+++ b/build/lib/PyDynamic/misc/filterstuff.py
@@ -1,21 +1,30 @@
 # -*- coding: utf-8 -*-
-"""
+r"""
 .. moduleauthor:: Sascha Eichstaedt (sascha.eichstaedt@ptb.de)
 
 A collection of methods which are related to filter design.
+
+This module contains the following functions:
+* db: Calculation of decibel values :math:`20\log_{10}(x)` for a vector of values
+* ua: Shortcut for calculation of unwrapped angle of complex values
+* grpdelay: Calculation of the group delay of a digital filter
+* mapinside: Maps the roots of polynomial with coefficients a inside the unit circle
+* kaiser_lowpass: Design of a FIR lowpass filter using the window technique with a Kaiser window.
+* isstable: Determine whether a given IIR filter is stable
+* savitzky_golay: Smooth (and optionally differentiate) data with a Savitzky-Golay filter
 
 """
 
 import numpy as np
 
-__all__ = ['grpdelay', 'kaiser_lowpass', 'isstable', 'savitzky_golay']
+__all__ = ['db', 'ua', 'grpdelay', 'mapinside', 'kaiser_lowpass', 'isstable', 'savitzky_golay']
 
 def db(vals):
     # Calculation of decibel values :math:`20\log_{10}(x)` for a vector of values    
     return 20*np.log10(np.abs(vals))
 
 def ua(vals):
-    # Calculation of unwrapped angle of complex values    
+    # Shortcut for calculation of unwrapped angle of complex values
     return np.unwrap(np.angle(vals))
 
     

--- a/build/lib/PyDynamic/uncertainty/propagate_MonteCarlo.py
+++ b/build/lib/PyDynamic/uncertainty/propagate_MonteCarlo.py
@@ -10,17 +10,18 @@ This module implements Monte Carlo methods for the propagation of uncertainties 
 
 """
 
+import sys
+
 # TODO: Implement updating Monte Carlo method
-# TODO: Implement repeated random number drawing from multivariate normal like in mvnrnd with re-using cholesky
+# TODO: Implement repeated random number drawing from multivariate normal
+#  like in mvnrnd with re-using cholesky
 import numpy as np
 import scipy as sp
-from numpy import matrix
-import sys
-from scipy.signal import lfilter
 import scipy.stats as stats
+from scipy.signal import lfilter
 
-from ..misc.tools import zerom
 from ..misc.filterstuff import isstable
+from ..misc.tools import zerom
 
 __all__ = ["MC", "SMC"]
 
@@ -57,7 +58,7 @@ class Normal_ZeroCorr():
 
 
 def MC(x,Ux,b,a,Uab,runs=1000,blow=None,alow=None,return_samples=False,shift=0,verbose=True):
-	"""Standard Monte Carlo method
+	r"""Standard Monte Carlo method
 
 	Monte Carlo based propagation of uncertainties for a digital filter (b,a)
 	with uncertainty matrix
@@ -154,7 +155,7 @@ def MC(x,Ux,b,a,Uab,runs=1000,blow=None,alow=None,return_samples=False,shift=0,v
 
 def SMC(x,noise_std,b,a,Uab=None,runs=1000,Perc=None,blow=None,alow=None,shift=0,\
 			return_samples=False,phi=None,theta=None,Delta=0.0):
-	"""Sequential Monte Carlo method
+	r"""Sequential Monte Carlo method
 
 	Sequential Monte Carlo propagation for a digital filter (b,a) with uncertainty
 	matrix :math:`U_{\theta}` for :math:`\theta=(a_1,\ldots,a_{N_a},b_0,\ldots,b_{N_b})^T`


### PR DESCRIPTION
The tests delivered a deprecation warning because of the math inside of some docstrings. I added an `r` in front of three docstrings to avoid those warnings.